### PR TITLE
Add default jvm args (-Xmx256m)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ tasks.withType<JavaCompile> {
 application {
     mainModule = "kurasava.ep.epmodpack"
     mainClass = "${mainModule.get()}.AppKt"
+    applicationDefaultJvmArgs = listOf("-Xmx256m")
 }
 
 val javafxVersion = project.property("javafx_version").toString()


### PR DESCRIPTION
Add default jvm args to application in build.gradle.kts. Now max memory is 256 mb.